### PR TITLE
Fix removal of VCS icon

### DIFF
--- a/hub_patcher.py
+++ b/hub_patcher.py
@@ -12,7 +12,7 @@ css = """<style>
 .pl-header__columns-wrapper > :nth-child(2) {display: none !important;}
 
 /* version control column value */
-.hCtBAQ {display: none !important;}
+.pl-item__row [role='presentation'] {display: none !important;}
 
 /* cloud services column value */
 .pl-item__row :nth-child(4) {display: none !important;}


### PR DESCRIPTION
The script was using the `hCtBAQ` class to select the VCS icon in the project view, however this no longer works in the `3.7.0-beta1` version of the Unity Hub (and presumably other future versions as well).
I'm guessing this is because the class name is generated at build time and changes with each release. Instead we can use the fact that the VCS element is the only element with the `role="presentation"` attribute set to select it in css and hide it.